### PR TITLE
Add *_raw functions to allow to outpout less clever html code

### DIFF
--- a/src/soup.mli
+++ b/src/soup.mli
@@ -413,6 +413,21 @@ val is_root : (_ node) -> bool
 
 (** {2 Printing} *)
 
+val pretty_print_raw : (_ node) -> string
+(** Converts the node tree rooted at the given node to a string formatted for
+    easy reading. Note that this can change the whitespace structure of the
+    HTML, so pretty-printed HTML may display differently in a browser than the
+    original parsed document. Pretty-printing is meant for inspection,
+    debugging, content diffs, etc., not browser viewing. The raw prefix means
+    that we would avoid clever rewriting rewriting, such as those transforming a
+    <meta/> in <meta>*)
+
+val to_string_raw : (_ node) -> string
+(** Converts the node tree rooted at the given node to a string, preserving
+    whitespace nodes and not minding human readability considerations. The raw prefix means
+    that we would avoid clever rewriting, such as those transforming a
+    <meta/> in <meta>*)
+
 val pretty_print : (_ node) -> string
 (** Converts the node tree rooted at the given node to a string formatted for
     easy reading. Note that this can change the whitespace structure of the

--- a/test/test.ml
+++ b/test/test.ml
@@ -816,7 +816,19 @@ let suites = [
       assert_equal document (document |> parse |> to_string);
       assert_bool "pretty_print"
         (equal_modulo_whitespace
-          (parse document) (parse document |> pretty_print |> parse)))
+          (parse document) (parse document |> pretty_print |> parse)));
+    ("pretty_print_raw" >:: fun _ ->
+          let document =
+            "<html><head><meta/></head><body class=\"testing\">\n<p>foo</p>\n<p>bar</p>\n</body></html>"
+          in
+          let expected_document =
+            "<html><head><meta></meta></head><body class=\"testing\">\n<p>foo</p>\n<p>bar</p>\n</body></html>"
+          in
+
+          assert_equal expected_document (document |> parse |> to_string_raw);
+          assert_bool "pretty_print_raw"
+            (equal_modulo_whitespace
+              (parse document) (parse document |> pretty_print_raw |> parse)))
   ]
 ]
 


### PR DESCRIPTION
This code adds two functions `pretty_print_raw` and `to_string_raw`. They have been (maybe incompletly) documented and tested.

## The problem

I was trying to write a script to remove all trailling `.html` from `href` attributes. (When url match specific pattern).

The files where produced by stog and then parsed again. But the `<meta …>` and other tags were creating errors, since they couldn’t be parsed back. This is  due to a transformation of tags like `<meta … ></meta>` or `<meta … />` to `<meta … >`.

With this patch, the generated HTML is now correctly parsed.

## Solution

The two functions allow to create tags which are always following this pattern

``` xml
<tag id="…" …> … </tag>
```

## Drawbacks

Since I don't know much the code, I used copy-paste heavily, which is maybe problem (according to [OCaml Guidelines](http://ocaml.org/learn/tutorials/guidelines.html#Nevercopypastecodewhenprogramming)). This may need a refactoring.
