### PR TITLE
Selector quoted attribute values

### DIFF
--- a/test/pages/quoted
+++ b/test/pages/quoted
@@ -15,5 +15,8 @@
 <p id="bracket]"/>
 <p id="parenthesis)"/>
 
+<div id="&quot;dquotes&quot;"/>
+<div id="simple&#39;quote"/>
+
 </body>
 </html>

--- a/test/pages/quoted
+++ b/test/pages/quoted
@@ -1,0 +1,19 @@
+<html>
+<body class="lists">
+
+<ul>
+  <li id="one" class="odd">Item 1</li>
+  <li id="two" class="even">Item 2</li>
+  <li id="three" class="odd">Item 3</li>
+</ul>
+
+<ol>
+  <li id="four" class="odd">Item 4</li>
+  <li id="five" class="even">Item 5</li>
+</ol>
+
+<p id="bracket]"/>
+<p id="parenthesis)"/>
+
+</body>
+</html>

--- a/test/test.ml
+++ b/test/test.ml
@@ -109,6 +109,36 @@ let suites = [
          "+ li#two")
         1);
 
+    ("parse-select-quoted" >:: fun _ ->
+      let soup = page "quoted" |> parse in
+      let test selector expected_count =
+        assert_equal ~msg:selector
+          (soup |> select selector |> count) expected_count
+      in
+
+      test "[id=\"one\"]" 1;
+      test "[id=\"six\"]" 0;
+      test "li[id=\"two\"]" 1;
+      test "li[class~=\"odd\"]" 3;
+      test "li[id^=\"t\"]" 2;
+      test "li[id$=\"e\"]" 3;
+      test "li[id*=\"n\"]" 1;
+      test "[id=\"bracket]\"]" 1;
+      test "[id=\"parenthesis)\"]" 1);
+
+    ("parse-fail-quoted" >:: fun _ ->
+      let soup = page "quoted" |> parse in
+      let test selector =
+        (try
+          soup |> select selector |> ignore; false
+        with
+        | Failure _ -> true
+        | _ -> false) |> assert_bool "expected Failure"
+      in
+
+      test "[id=\"one]";
+      test "[id=\"tw\"o\"]");
+
     ("parse-select-html5" >:: fun _ ->
       let soup = page "html5" |> parse in
       let test selector expected_count =

--- a/test/test.ml
+++ b/test/test.ml
@@ -117,14 +117,26 @@ let suites = [
       in
 
       test "[id=\"one\"]" 1;
+      test "[id='one']" 1;
       test "[id=\"six\"]" 0;
+      test "[id='six']" 0;
       test "li[id=\"two\"]" 1;
+      test "li[id='two']" 1;
       test "li[class~=\"odd\"]" 3;
+      test "li[class~='odd']" 3;
       test "li[id^=\"t\"]" 2;
+      test "li[id^='t']" 2;
       test "li[id$=\"e\"]" 3;
+      test "li[id$='e']" 3;
       test "li[id*=\"n\"]" 1;
+      test "li[id*='n']" 1;
       test "[id=\"bracket]\"]" 1;
-      test "[id=\"parenthesis)\"]" 1);
+      test "[id=\"parenthesis)\"]" 1;
+      test "[id='\"dquotes\"']" 1;
+      test "[id=\"dquotes\"]" 0;
+      test "[id=\"\\\"dquotes\\\"\"]" 1;
+      test "[id=\"simple'quote\"]" 1;
+      test "[id='simple\\'quote']" 1);
 
     ("parse-fail-quoted" >:: fun _ ->
       let soup = page "quoted" |> parse in
@@ -136,8 +148,10 @@ let suites = [
         | _ -> false) |> assert_bool "expected Failure"
       in
 
-      test "[id=\"one]";
-      test "[id=\"tw\"o\"]");
+      test "[id=\"unterminated]";
+      test "[id=\"un\"escaped\"]",
+      test "[id='unterminated]";
+      test "[id='un'escaped']");
 
     ("parse-select-html5" >:: fun _ ->
       let soup = page "html5" |> parse in


### PR DESCRIPTION
According to reference https://www.w3.org/TR/css3-selectors/#attribute-selectors and https://www.w3.org/TR/CSS21/syndata.html#strings, attributes values in selectors can be either identifier or quoted strings.
While identifiers are syntactically heavily restricted and I don't see any problem with lambdasoup being more resilient, selectors like

`soup $ "[attr='a value']"`
match markups of the form
`<markup attr="&#39;a value&#39;"/>`

and similarly
`soup $ "[attr=\"a value\"]"`
match markups of the form
`<markup attr="&quot;a value&quot;"/>`

I see a few problems with that : 
 - It is counter-intuitive and not compatible with the standard : one would expect [attr='a value'] to parse simple quotes as delimiters, and rather match `<markup attr="a value">`.
 - Currently, there is no mean to select attributes with values containing characters ')' or ']' since the parser understand it as final delimiters without a way to escape it.

This PR tries to solve the problem by 
1) modifying parse_quoted_string to parse string delimited by simple or double quotes, with possibility of escaping the delimiter inside the string if preceded by '\\'
2) in the function that parses attributes values (parse_string), parse the string as a quoted string using parse_quoted_string if it begins with a simple or a double quote, or parse it exactly as before if it doesn't.
3) Adding some tests to validate the behavior