### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ let () =
   with Not_found -> ()
 ;;
 
-#use "topfind";;
+# use "topfind";;
 ```
 
 Then, run `ocaml -short-paths` to start the top-level, and scrape away!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
